### PR TITLE
Add Containerfile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,6 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+    
+    - name: Build Image
+      run: docker build -t localhost/go-init -f ./Containerfile .

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,10 @@
+FROM registry.redhat.io/ubi9/go-toolset:1.21 as builder
+ARG GO_INIT_VERSION="1.0.0"
+COPY go.mod go.mod
+COPY main.go main.go
+RUN go build -ldflags="-X 'main.versionString=${GO_INIT_VERSION}'" -o go-init main.go
+
+FROM registry.redhat.io/ubi9/ubi-micro:9.4
+
+COPY --from=builder /opt/app-root/src/go-init /usr/bin/go-init
+ENTRYPOINT [ "/usr/bin/go-init" ]

--- a/Containerfile
+++ b/Containerfile
@@ -1,10 +1,10 @@
-FROM registry.redhat.io/ubi9/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
 ARG GO_INIT_VERSION="1.0.0"
 COPY go.mod go.mod
 COPY main.go main.go
 RUN go build -ldflags="-X 'main.versionString=${GO_INIT_VERSION}'" -o go-init main.go
 
-FROM registry.redhat.io/ubi9/ubi-micro:9.4
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.4
 
 COPY --from=builder /opt/app-root/src/go-init /usr/bin/go-init
 ENTRYPOINT [ "/usr/bin/go-init" ]


### PR DESCRIPTION
Add a `Containerfile` as a prerequisite for building container images. The images reference `registry.access.redhat.com`, which does not require authentication. The output image is based on ubi-micro, Red Hat's flavor of a "distroless" image (no extra packages can be installed).

The output image can be used in a few ways:

1. Execute commands directly if the underlying `ubi-micro` image has the appropriate program.
2. Use the `go-init` image as the base of your application in a Dockerfile/Containerfile.
3. Extract go-init from the `/usr/bin` directory and place it in a different image within a multi-stage build.